### PR TITLE
Update CheatManager.hpp

### DIFF
--- a/R3nzSkin/CheatManager.hpp
+++ b/R3nzSkin/CheatManager.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-
 #include "Config.hpp"
 #include "GUI.hpp"
 #include "Hooks.hpp"
@@ -11,23 +10,26 @@
 
 class CheatManager {
 public:
-	void start() noexcept
-	{
-		this->hooks = std::make_unique<Hooks>();
-		this->config = std::make_unique<Config>();
-		this->gui = std::make_unique<GUI>();
-		this->memory = std::make_unique<Memory>();
-		this->database = std::make_unique<SkinDatabase>();
-		this->logger = std::make_unique<R3nzSkinLogger>();
-	}
+    CheatManager() noexcept :
+        hooks(std::make_unique<Hooks>()),
+        config(std::make_unique<Config>()),
+        gui(std::make_unique<GUI>()),
+        memory(std::make_unique<Memory>()),
+        database(std::make_unique<SkinDatabase>()),
+        logger(std::make_unique<R3nzSkinLogger>()),
+        cheatState(true)
+    {}
 
-	bool cheatState{ true };
-	std::unique_ptr<Hooks> hooks;
-	std::unique_ptr<Config> config;
-	std::unique_ptr<GUI> gui;
-	std::unique_ptr<Memory> memory;
-	std::unique_ptr<SkinDatabase> database;
-	std::unique_ptr<R3nzSkinLogger> logger;
+    
+
+private:
+    bool cheatState;
+    std::unique_ptr<Hooks> hooks;
+    std::unique_ptr<Config> config;
+    std::unique_ptr<GUI> gui;
+    std::unique_ptr<Memory> memory;
+    std::unique_ptr<SkinDatabase> database;
+    std::unique_ptr<R3nzSkinLogger> logger;
 };
 
 inline CheatManager cheatManager;


### PR DESCRIPTION
Utilized a member initialization list in the constructor, which can be more efficient than assignment inside the constructor body because it avoids default-constructing the member variables and then assigning to them.

Moved the member variables to the private section of the class to encapsulate the internal state and prevent unwanted external access or modification. This ensures that the class is used as intended and protects its internal state.

Retained the use of noexcept specifier in the constructor, signaling that it doesn’t throw exceptions.